### PR TITLE
Feature/improve interoperability with rails and active model serializer

### DIFF
--- a/lib/cpf.rb
+++ b/lib/cpf.rb
@@ -32,7 +32,7 @@ class CPF
   end
 
   def initialize(number)
-    @number = number.to_s
+    @number = number.to_s.gsub(/\D/, '')
   end
 
   def number=(number)

--- a/lib/cpf.rb
+++ b/lib/cpf.rb
@@ -51,8 +51,8 @@ class CPF
   end
 
   def valid?
-    return unless stripped.size == 11
-    return if BLACKLIST.include?(stripped)
+    return false unless stripped.size == 11
+    return false if BLACKLIST.include?(stripped)
 
     _numbers = numbers[0...9]
     _numbers << VerifierDigit.generate(_numbers)

--- a/lib/cpf.rb
+++ b/lib/cpf.rb
@@ -61,6 +61,11 @@ class CPF
     _numbers[-2, 2] == numbers[-2, 2]
   end
 
+  # validates_associated in the parent model requires the existence of this method
+  def marked_for_destruction?
+    false
+  end
+
   private
   def numbers
     @numbers ||= stripped.each_char.to_a.map(&:to_i)

--- a/lib/cpf.rb
+++ b/lib/cpf.rb
@@ -66,7 +66,11 @@ class CPF
     false
   end
 
+  # HTML views
   alias_method :to_s, :formatted
+
+  # JSON views
+  delegate :as_json, to: :number
 
   private
   def numbers

--- a/lib/cpf.rb
+++ b/lib/cpf.rb
@@ -66,6 +66,8 @@ class CPF
     false
   end
 
+  alias_method :to_s, :formatted
+
   private
   def numbers
     @numbers ||= stripped.each_char.to_a.map(&:to_i)


### PR DESCRIPTION
This improves integration with ActiveModelSerializer by allowing this to work (which is very handy for using the Value Object Pattern):

``` ruby
# app/models/user.rb
class User < ActiveRecord::Base
  validates :cpf, associated: true, allow_nil: true
  ...

  def cpf=(number)
    super(number)
    @cpf = number ? CPF.new(number) : nil
    @cpf
  end

  def cpf
    @cpf ||= CPF.new(read_attribute(:cpf)) if read_attribute(:cpf)
  end
end

...

u = User.first
u.valid? # true

u.cpf = "12345678901"
u.valid? # false
u.errors[:cpf] # "invalid"
```

Also, in Rails forms work better if the method responds well to "to_s"

``` slim
# app/views/users/edit.html.slim

= simple_form_for(@user, url: confirmation_path(:user), html: {method: :post}) do |f|
  = f.error_notification
  = f.full_error :confirmation_token
  .form-inputs
    = f.input :name, required: true
    = f.input :cpf, required: true
  .form-actions
    = f.button :submit
```

``` html
<!-- HTML rendered in the browser -->

<input class="string optional" type="text" value="XXX.XXX.XXX-XX" name="user[cpf]" id="user_cpf">
```
