### PR TITLE
Reject CNPJs with lowercase letters.

### DIFF
--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/cache@v4
         with:

--- a/lib/cnpj.rb
+++ b/lib/cnpj.rb
@@ -44,7 +44,7 @@ class CNPJ
   end
 
   def initialize(number, strict = false)
-    @number = number.to_s.upcase
+    @number = number.to_s
     @strict = strict
   end
 

--- a/lib/cpf_cnpj/version.rb
+++ b/lib/cpf_cnpj/version.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/OneClassPerFile
+
 module CpfCnpj
   VERSION = "1.0.1"
 end
@@ -11,3 +13,4 @@ end
 class CNPJ
   VERSION = CpfCnpj::VERSION
 end
+# rubocop:enable Style/OneClassPerFile

--- a/test/cnpj_test.rb
+++ b/test/cnpj_test.rb
@@ -36,10 +36,16 @@ class CnpjTest < Minitest::Test
     assert CNPJ.valid?(number)
   end
 
-  test "validates formatted strings with letters (lowercase)" do
-    number = "12.abc.345/01de-35"
+  test "rejects strings with lowercase letters" do
+    refute CNPJ.valid?("12.abc.345/01de-35")
+    refute CNPJ.valid?("12abc34501de35")
+    refute CNPJ.valid?("12.AbC.345/01dE-35")
+  end
 
-    assert CNPJ.valid?(number)
+  test "strictly rejects strings with lowercase letters" do
+    refute CNPJ.valid?("12.abc.345/01de-35", strict: true)
+    refute CNPJ.valid?("12abc34501de35", strict: true)
+    refute CNPJ.valid?("12.AbC.345/01dE-35", strict: true)
   end
 
   test "formats number" do


### PR DESCRIPTION
The Receita Federal spec for the alphanumeric CNPJ requires uppercase letters only, so treating lowercase as valid diverges from the official rule. Drop the `upcase` normalization in `CNPJ#initialize` so lowercase (and mixed-case) inputs fall outside `VALIDATION_SIZE_REGEX` and are reported as invalid.

Reference: https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/publicacoes/perguntas-e-respostas/cnpj/cnpj-alfanumerico.pdf